### PR TITLE
update workflow get-action-data

### DIFF
--- a/.github/workflows/get-action-data.yml
+++ b/.github/workflows/get-action-data.yml
@@ -15,7 +15,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: devops-actions/load-available-actions@v1.2.12
+    # fork of devops-actions/load-available-actions
+    - uses: paritytech-actions/load-available-actions@v1.2.12
       name: Load available actions
       id: load-actions
       with:
@@ -24,7 +25,7 @@ jobs:
 
     # todo: convert this part into an action to make it more transferable. Don't forget to update the readme then!
     - run: npm install fs
-    - uses: actions/github-script@v5
+    - uses: actions/github-script@v6
       with:
         script: |
           let actions = `${{ steps.load-actions.outputs.actions }}`
@@ -38,14 +39,14 @@ jobs:
           })
 
     - name: Upload result file as artefact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: actions
         path: actions-data.json
 
     - name: Upload json to this repository
-      #uses: LasyIsLazy/github-upload-action@v0.1.0
-      uses: rajbos-actions/github-upload-action@v0.2.0
+      # fork of LasyIsLazy/github-upload-action
+      uses: paritytech-actions/github-upload-action@v0.2.0
       with:
         access-token: ${{ secrets.PAT }}
         file-path: actions-data.json


### PR DESCRIPTION
This PR updates `get-action-data.yml` to our needs. Third party GHA's replaced with the forks in current org